### PR TITLE
Update bindings to includes all archs

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '13.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source       = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-308ed57/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source       = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-7e063c5/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPRust.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '13.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source       = { :http => "https://github.com/xmtp/libxmtp/releases/download/test-swift-bindings-ecb15b7/LibXMTPSwiftFFI.zip" }
+  s.source       = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-308ed57/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPRust.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '0.4.1'
+  s.version          = '0.4.1-beta0'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'

--- a/Package.swift
+++ b/Package.swift
@@ -23,8 +23,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-308ed57/LibXMTPSwiftFFI.zip",
-            checksum: "61e139006925ca075f838dd6cc1be00268081882d6e64bbb103b344dbc2741bb"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-7e063c5/LibXMTPSwiftFFI.zip",
+            checksum: "3fca7883868c9116289a5d84336d70a079978d9095e13e685994e4f08bd754e0"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -23,8 +23,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/test-swift-bindings-ecb15b7/LibXMTPSwiftFFI.zip",
-            checksum: "82ffd012586c96cae38ce48010f828b3094023d745a891b79fe7afc39767c95a"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-308ed57/LibXMTPSwiftFFI.zip",
+            checksum: "61e139006925ca075f838dd6cc1be00268081882d6e64bbb103b344dbc2741bb"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]


### PR DESCRIPTION
`pod spec lint` was failing because the bindings were missing some architecture types. This was fixed here: https://github.com/xmtp/libxmtp/pull/465

This change can be verified by running `pod spec lint LibXMTP.podspec` in the root folder + branch of this PR