### PR TITLE
Update to libxmtp  bindings release 43bc889

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '0.4.1-beta1'
+  s.version          = '0.4.1-beta2'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '13.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source       = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-9126afd/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source       = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-43bc889/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPRust.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -23,8 +23,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-9126afd/LibXMTPSwiftFFI.zip",
-            checksum: "5a5a754cc648d41eb2bcbd8afd5cfeecddd0000795c9c948d20da445f135804f"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-43bc889/LibXMTPSwiftFFI.zip",
+            checksum: "dbe55c7011a88603063f0a9d86783a168678b9cb06c877e47813355cc9a81a1f"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@ Swift Package and Cocoapod that wraps an XCFramework emitted by the `bindings_ff
 
 **NOTE**: This package is NOT meant to be directly consumed by end users. Instead see [xmtp-ios](https://github.com/xmtp/xmtp-ios) which depends upon this package.
 
+## Process for updating from a [libxmtp](https://github.com/xmtp/libxmtp) Swift Binding Release (work in progress!)
+
+1. From [libxmtp](https://github.com/xmtp/libxmtp) repo, go to Action => Release Swift Bindings => Run workflow (select branch to release from)
+2. Verify success in [libxmtp releases](https://github.com/xmtp/libxmtp/releases)
+3. Create a new branch in the `libxmtp-swift` repo
+4. With `libxmtp` repo and `libxmtp-swift` (this repo) cloned locally in sibling directories, and `libxmtp` checked out to the correct release commit, run the script (this should update `libxmtp-swift/Sources` directory):
+   ```
+   bindings_ffi/run_swift_local.sh
+   ```
+5. Update `LibXMTP.podspec` version, and then point `s.source` url to `LibXMTPSwiftFFI.zip` from the libxmtp release you created (verify the podspec is correct using the command `pod spec lint LibXMTP.podspec`) 
+6. Update `Package.swift` binary target url to point to the same `LibXMTPSwiftFFI.zip` from the step above
+7. Update the `Package.swift` checksum to the checksum from the from the libxmtp release you created
+8. Create a PR and merge to `libxmtp-swift` main branch
+9. Tag your commit on main using the  value of the `s.version` from the `LibXMTP.podspec` that you bumped earlier  in step 5. 
+10. Publish the Cocoapod using the command `pod trunk push LibXMTP.podspec` ([see Cocoapod guide if you have not yet registered](https://guides.cocoapods.org/making/getting-setup-with-trunk.html))
+
+You should now be able to reference the Swift Package and Cocoapod from xmtp-ios using the format below.
 
 ### For testing purposes
 

--- a/Sources/LibXMTP/xmtpv3.swift
+++ b/Sources/LibXMTP/xmtpv3.swift
@@ -728,6 +728,7 @@ public func FfiConverterTypeFfiGroup_lower(_ value: FfiGroup) -> UnsafeMutableRa
 
 public protocol FfiStreamCloserProtocol {
     func end()
+    func isClosed() -> Bool
 }
 
 public class FfiStreamCloser: FfiStreamCloserProtocol {
@@ -749,6 +750,15 @@ public class FfiStreamCloser: FfiStreamCloserProtocol {
             rustCall {
                 uniffi_xmtpv3_fn_method_ffistreamcloser_end(self.pointer, $0)
             }
+    }
+
+    public func isClosed() -> Bool {
+        return try! FfiConverterBool.lift(
+            try!
+                rustCall {
+                    uniffi_xmtpv3_fn_method_ffistreamcloser_is_closed(self.pointer, $0)
+                }
+        )
     }
 }
 
@@ -3204,6 +3214,9 @@ private var initializationResult: InitializationResult {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_xmtpv3_checksum_method_ffistreamcloser_end() != 47211 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_xmtpv3_checksum_method_ffistreamcloser_is_closed() != 37884 {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_xmtpv3_checksum_method_ffiv2apiclient_batch_query() != 10812 {


### PR DESCRIPTION
See new README instructions for updating Swift Package and Cocoapod:

https://github.com/xmtp/libxmtp-swift/blob/cv/bindings-libxmtp-43bc889/README.md