### PR TITLE
Add Linker Settings To Fix CLI Swift Testing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,11 @@ let package = Package(
         .target(
             name: "LibXMTP",
             dependencies: ["LibXMTPSwiftFFI"],
-            path: "Sources/LibXMTP"
+            path: "Sources/LibXMTP",
+            linkerSettings: [
+                .linkedFramework("CoreFoundation"),
+                .linkedFramework("SystemConfiguration")
+            ]
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",


### PR DESCRIPTION
Currently building this package from the command line and running tests triggers linker failures. This will be needed to restore upstream testing in the XMPT-iOS SDK.

**Example:**
```
$ swift build -v
$ swift test -v // fails with linker errors
```

Adding linker dependencies to the target in `Package.swift` fixes the problem.