### PR TITLE
update rust libxmtp for group name functions

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '0.4.4-beta3'
+  s.version          = '0.4.4-beta4'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '13.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source       = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-5b62701/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source       = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-40dedd8/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPSwiftFFI.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-5b62701/LibXMTPSwiftFFI.zip",
-            checksum: "ae43fa8c1974825f77c00192755649cde343d31923198c4b6d4bd2ad68358977"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-40dedd8/LibXMTPSwiftFFI.zip",
+            checksum: "61700ca94b9d70bda93f9c12a995067c2d2dbaaae8119e6f9bdf7fd0eb309e78"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/Sources/LibXMTP/libxmtp-version.txt
+++ b/Sources/LibXMTP/libxmtp-version.txt
@@ -1,3 +1,3 @@
-Version: 5b62701
-Branch: main
-Date: 2024-04-18 03:59:02 +0000
+Version: 40dedd8
+Branch: HEAD
+Date: 2024-04-23 22:24:01 +0000

--- a/Sources/LibXMTP/xmtpv3.swift
+++ b/Sources/LibXMTP/xmtpv3.swift
@@ -581,6 +581,7 @@ public protocol FfiGroupProtocol {
     func createdAtNs() -> Int64
     func findMessages(opts: FfiListMessagesOptions) throws -> [FfiMessage]
     func groupMetadata() throws -> FfiGroupMetadata
+    func groupName() throws -> String
     func id() -> Data
     func isActive() throws -> Bool
     func listMembers() throws -> [FfiGroupMember]
@@ -589,6 +590,7 @@ public protocol FfiGroupProtocol {
     func send(contentBytes: Data) async throws -> Data
     func stream(messageCallback: FfiMessageCallback) async throws -> FfiStreamCloser
     func sync() async throws
+    func updateGroupName(groupName: String) async throws
 }
 
 public class FfiGroup: FfiGroupProtocol {
@@ -651,6 +653,14 @@ public class FfiGroup: FfiGroupProtocol {
         return try FfiConverterTypeFfiGroupMetadata.lift(
             rustCallWithError(FfiConverterTypeGenericError.lift) {
                 uniffi_xmtpv3_fn_method_ffigroup_group_metadata(self.pointer, $0)
+            }
+        )
+    }
+
+    public func groupName() throws -> String {
+        return try FfiConverterString.lift(
+            rustCallWithError(FfiConverterTypeGenericError.lift) {
+                uniffi_xmtpv3_fn_method_ffigroup_group_name(self.pointer, $0)
             }
         )
     }
@@ -749,6 +759,22 @@ public class FfiGroup: FfiGroupProtocol {
             rustFutureFunc: {
                 uniffi_xmtpv3_fn_method_ffigroup_sync(
                     self.pointer
+                )
+            },
+            pollFunc: ffi_xmtpv3_rust_future_poll_void,
+            completeFunc: ffi_xmtpv3_rust_future_complete_void,
+            freeFunc: ffi_xmtpv3_rust_future_free_void,
+            liftFunc: { $0 },
+            errorHandler: FfiConverterTypeGenericError.lift
+        )
+    }
+
+    public func updateGroupName(groupName: String) async throws {
+        return try await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_xmtpv3_fn_method_ffigroup_update_group_name(
+                    self.pointer,
+                    FfiConverterString.lower(groupName)
                 )
             },
             pollFunc: ffi_xmtpv3_rust_future_poll_void,
@@ -3592,6 +3618,9 @@ private var initializationResult: InitializationResult {
     if uniffi_xmtpv3_checksum_method_ffigroup_group_metadata() != 3690 {
         return InitializationResult.apiChecksumMismatch
     }
+    if uniffi_xmtpv3_checksum_method_ffigroup_group_name() != 3391 {
+        return InitializationResult.apiChecksumMismatch
+    }
     if uniffi_xmtpv3_checksum_method_ffigroup_id() != 35243 {
         return InitializationResult.apiChecksumMismatch
     }
@@ -3614,6 +3643,9 @@ private var initializationResult: InitializationResult {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_xmtpv3_checksum_method_ffigroup_sync() != 9422 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_xmtpv3_checksum_method_ffigroup_update_group_name() != 29940 {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_xmtpv3_checksum_method_ffigroupmetadata_conversation_type() != 37015 {


### PR DESCRIPTION
Adds the following new functions for xmtp-ios for FfiGroup:

    func groupName() throws -> String

    func updateGroupName(groupName: String) async throws
