### PR TITLE
updated for permission level on members struct

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '13.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source       = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-c86272d/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source       = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-bd8360b/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPSwiftFFI.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-c86272d/LibXMTPSwiftFFI.zip",
-            checksum: "c9a5fdc8ffc936f1f3901cb3cb3aedea06782a68d962ef498696fd7e4f888c48"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-bd8360b/LibXMTPSwiftFFI.zip",
+            checksum: "90928c0849706499a8ec034c0bd19858b50edafa08c1ab22945656d6b002cd5e"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/Sources/LibXMTP/libxmtp-version.txt
+++ b/Sources/LibXMTP/libxmtp-version.txt
@@ -1,3 +1,3 @@
-Version: c86272d
-Branch: HEAD
-Date: 2024-05-28 21:11:59 +0000
+Version: bd8360b
+Branch: main
+Date: 2024-05-29 16:47:55 +0000


### PR DESCRIPTION
PR does not update the podspec version because the latest commit on main is not tagged or released to cocoapods yet.