### PR TITLE
Update libxmtp to for pending commit fix

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '0.5.1-beta0'
+  s.version          = '0.5.1-beta1'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '13.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source       = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-46fad30/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source       = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-6e8dcd1/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPSwiftFFI.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-46fad30/LibXMTPSwiftFFI.zip",
-            checksum: "966a3fe8a55fea96b2e0d0823ecd30834c77a3173e0cb9efe4d93dbd9c0e212c"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-6e8dcd1/LibXMTPSwiftFFI.zip",
+            checksum: "698533c87b78b24f230ef87c65cd2385ac80864b6f0ea04e51199bff84b8e0a6"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/Sources/LibXMTP/libxmtp-version.txt
+++ b/Sources/LibXMTP/libxmtp-version.txt
@@ -1,3 +1,3 @@
-Version: 46fad302
+Version: 6e8dcd1f
 Branch: main
-Date: 2024-06-04 02:30:29 +0000
+Date: 2024-06-10 18:27:13 +0000


### PR DESCRIPTION
Notable Updates:
- Default group name is now empty string
- Now correctly clearing pending commits after invalid permission commits