### PR TITLE
update bindings to libxmtp e4cfade

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '0.5.4-beta0'
+  s.version          = '0.5.4-beta1'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '14.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source       = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-feb4864/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source       = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-e4cfade/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPSwiftFFI.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-feb4864/LibXMTPSwiftFFI.zip",
-            checksum: "144754c7406251bcf64e8c578f4081a3fe6753dd7592c94f0c719424f26c9019"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-e4cfade/LibXMTPSwiftFFI.zip",
+            checksum: "4c0e1dce47d8dc846a134b3d7c3997a10de066707c64655e9302a7e48fad9ff9"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/Sources/LibXMTP/libxmtp-version.txt
+++ b/Sources/LibXMTP/libxmtp-version.txt
@@ -1,3 +1,3 @@
-Version: feb48641
+Version: e4cfade7
 Branch: main
-Date: 2024-06-26 22:31:21 +0000
+Date: 2024-07-01 19:23:57 +0000


### PR DESCRIPTION
- update permission function
- read permission policy set
- update/read group description
- admins can update new metadata fields without setting policy first