### PR TITLE
Bump to latest versions of SDK

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '0.5.8-beta1'
+  s.version          = '0.5.8-beta2'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '14.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source       = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-023fef7/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source       = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-82ee23b/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPSwiftFFI.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-023fef7/LibXMTPSwiftFFI.zip",
-            checksum: "02f660eb2361cc0dd90bfccae40b89e53d869856d1b6a742f45d314e9cc832e8"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-82ee23b/LibXMTPSwiftFFI.zip",
+            checksum: "931a3704fc376306adb30944ed194c7c876c8583a2d1a365fee4679dc02ea868"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/Sources/LibXMTP/libxmtp-version.txt
+++ b/Sources/LibXMTP/libxmtp-version.txt
@@ -1,3 +1,3 @@
-Version: 023fef7e
-Branch: HEAD
-Date: 2024-08-26 15:07:03 +0000
+Version: 82ee23b1
+Branch: main
+Date: 2024-08-29 23:40:55 +0000


### PR DESCRIPTION
## What's Changed
* fix musl-tools by @insipx in https://github.com/xmtp/libxmtp/pull/993
* Stop setting new lifetimes by @neekolas in https://github.com/xmtp/libxmtp/pull/964
* Refactor message history sync, add to CLI by @tuddman in https://github.com/xmtp/libxmtp/pull/930
* Generate latest protos, update affected types by @rygine in https://github.com/xmtp/libxmtp/pull/1009
* Fix node bindings release workflow by @rygine in https://github.com/xmtp/libxmtp/pull/1013
* `xmtp_cryptography` wasm32 target by @insipx in https://github.com/xmtp/libxmtp/pull/1012
* Various updates by @rygine in https://github.com/xmtp/libxmtp/pull/1014
* Add libxmtp version to requests by @neekolas in https://github.com/xmtp/libxmtp/pull/1011
* Store or ignore group messages by @neekolas in https://github.com/xmtp/libxmtp/pull/1019
* Fix send update interval ns calculation, move to configuration by @cameronvoell in https://github.com/xmtp/libxmtp/pull/1008
* Create group with initial members by @neekolas in https://github.com/xmtp/libxmtp/pull/1020
* Retry PoolNeedsConnection Errors by @nplasterer in https://github.com/xmtp/libxmtp/pull/1010