### PR TITLE
Update to libxmtp 4.2.0-dev.38cf550

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '4.2.0-dev.35ab145'
+  s.version          = '4.2.0-dev.38cf550'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'


### PR DESCRIPTION
This PR updates the Swift bindings to libxmtp version 4.2.0-dev.38cf550. 
  
Changes:
- Updated Sources directory with latest Swift bindings
- Updated LibXMTP.podspec version to 4.2.0-dev.38cf550
- Updated binary URLs to point to the new release
- Updated checksum in Package.swift