### PR TITLE
Update to libxmtp 4.2.0-dev.4132dcf

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '4.2.0-dev.59df9d1'
+  s.version          = '4.2.0-dev.4132dcf'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '14.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-dev.59df9d1/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-dev.4132dcf/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPSwiftFFI.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-dev.59df9d1/LibXMTPSwiftFFI.zip",
-            checksum: "980f5a447b13fe973c76e179eddf3fe0a57d89e470cf96f9779e56c060b80450"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-dev.4132dcf/LibXMTPSwiftFFI.zip",
+            checksum: "2493f0906c127a9d4963c4e44ad7a16d2bc64274c4a9f3239dc345923cd0bc92"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/Sources/LibXMTP/libxmtp-version.txt
+++ b/Sources/LibXMTP/libxmtp-version.txt
@@ -1,3 +1,3 @@
-Version: 59df9d1
+Version: 4132dcf
 Branch: HEAD
-Date: 2025-04-14 23:20:12 +0000
+Date: 2025-04-15 12:16:09 +0000


### PR DESCRIPTION
This PR updates the Swift bindings to libxmtp version 4.2.0-dev.4132dcf. 
  
Changes:
- Updated Sources directory with latest Swift bindings
- Updated LibXMTP.podspec version to 4.2.0-dev.4132dcf
- Updated binary URLs to point to the new release
- Updated checksum in Package.swift