### PR TITLE
Update to libxmtp 4.2.0-dev.d811cc6

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '4.2.0-dev.4132dcf'
+  s.version          = '4.2.0-dev.d811cc6'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '14.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-dev.4132dcf/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-dev.d811cc6/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPSwiftFFI.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-dev.4132dcf/LibXMTPSwiftFFI.zip",
-            checksum: "2493f0906c127a9d4963c4e44ad7a16d2bc64274c4a9f3239dc345923cd0bc92"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-dev.d811cc6/LibXMTPSwiftFFI.zip",
+            checksum: "0e675fe2970ab1dc7791b34c131ec996ee3c9943128eef5e2fcc951c87819f9f"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/Sources/LibXMTP/libxmtp-version.txt
+++ b/Sources/LibXMTP/libxmtp-version.txt
@@ -1,3 +1,3 @@
-Version: 4132dcf
+Version: d811cc6
 Branch: HEAD
-Date: 2025-04-15 12:16:09 +0000
+Date: 2025-04-16 21:10:15 +0000

--- a/Sources/LibXMTP/xmtpv3.swift
+++ b/Sources/LibXMTP/xmtpv3.swift
@@ -3762,7 +3762,7 @@ public protocol FfiXmtpClientProtocol: AnyObject, Sendable {
     
     func signatureRequest()  -> FfiSignatureRequest?
     
-    func syncPreferences() async throws  -> UInt32
+    func syncPreferences() async throws  -> UInt64
     
     /**
      * A utility function to easily verify that a piece of text was signed by this installation.
@@ -4277,7 +4277,7 @@ open func signatureRequest() -> FfiSignatureRequest?  {
 })
 }
     
-open func syncPreferences()async throws  -> UInt32  {
+open func syncPreferences()async throws  -> UInt64  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
@@ -4286,10 +4286,10 @@ open func syncPreferences()async throws  -> UInt32  {
                     
                 )
             },
-            pollFunc: ffi_xmtpv3_rust_future_poll_u32,
-            completeFunc: ffi_xmtpv3_rust_future_complete_u32,
-            freeFunc: ffi_xmtpv3_rust_future_free_u32,
-            liftFunc: FfiConverterUInt32.lift,
+            pollFunc: ffi_xmtpv3_rust_future_poll_u64,
+            completeFunc: ffi_xmtpv3_rust_future_complete_u64,
+            freeFunc: ffi_xmtpv3_rust_future_free_u64,
+            liftFunc: FfiConverterUInt64.lift,
             errorHandler: FfiConverterTypeGenericError_lift
         )
 }
@@ -10097,7 +10097,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_xmtpv3_checksum_method_ffixmtpclient_signature_request() != 18270) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_xmtpv3_checksum_method_ffixmtpclient_sync_preferences() != 23343) {
+    if (uniffi_xmtpv3_checksum_method_ffixmtpclient_sync_preferences() != 59168) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_ffixmtpclient_verify_signed_with_installation_key() != 3285) {


### PR DESCRIPTION
This PR updates the Swift bindings to libxmtp version 4.2.0-dev.d811cc6. 
  
Changes:
- Updated Sources directory with latest Swift bindings
- Updated LibXMTP.podspec version to 4.2.0-dev.d811cc6
- Updated binary URLs to point to the new release
- Updated checksum in Package.swift