### PR TITLE
Update to libxmtp 4.2.0-dev.4ba3b55

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '4.2.0-dev.d811cc6'
+  s.version          = '4.2.0-dev.4ba3b55'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '14.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-dev.d811cc6/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-dev.4ba3b55/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPSwiftFFI.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-dev.d811cc6/LibXMTPSwiftFFI.zip",
-            checksum: "0e675fe2970ab1dc7791b34c131ec996ee3c9943128eef5e2fcc951c87819f9f"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-dev.4ba3b55/LibXMTPSwiftFFI.zip",
+            checksum: "9a5a984f83a9c85f36fe61b614d7f4a465ff5d5b3f7b37a70df2c46698335824"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/Sources/LibXMTP/libxmtp-version.txt
+++ b/Sources/LibXMTP/libxmtp-version.txt
@@ -1,3 +1,3 @@
-Version: d811cc6
+Version: 4ba3b55
 Branch: HEAD
-Date: 2025-04-16 21:10:15 +0000
+Date: 2025-04-21 18:59:39 +0000


### PR DESCRIPTION
This PR updates the Swift bindings to libxmtp version 4.2.0-dev.4ba3b55. 
  
Changes:
- Updated Sources directory with latest Swift bindings
- Updated LibXMTP.podspec version to 4.2.0-dev.4ba3b55
- Updated binary URLs to point to the new release
- Updated checksum in Package.swift