### PR TITLE
Update to libxmtp 4.2.0-rc2

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '4.2.0-rc1'
+  s.version          = '4.2.0-rc2'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '14.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-rc1.9ce24d1/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-rc2.51542b6/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPSwiftFFI.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-rc1.9ce24d1/LibXMTPSwiftFFI.zip",
-            checksum: "19c2ed80c1a3ad91643a7afc96504ad07e3deceec63a1c201ee220ede50c9f18"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-rc2.51542b6/LibXMTPSwiftFFI.zip",
+            checksum: "7a153b398d8808c9025dcc20436a891159b18f0e5927e183b034b22d2f4b3cd5"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/Sources/LibXMTP/libxmtp-version.txt
+++ b/Sources/LibXMTP/libxmtp-version.txt
@@ -1,3 +1,3 @@
-Version: 9ce24d1
+Version: 51542b6
 Branch: HEAD
-Date: 2025-05-07 17:45:18 +0000
+Date: 2025-05-08 23:42:20 +0000

--- a/Sources/LibXMTP/xmtpv3.swift
+++ b/Sources/LibXMTP/xmtpv3.swift
@@ -8009,7 +8009,7 @@ extension FfiPermissionUpdateType: Equatable, Hashable {}
 
 public enum FfiPreferenceUpdate {
     
-    case hmac(key: Data, cycledAtNs: Int64
+    case hmac(key: Data
     )
 }
 
@@ -8028,7 +8028,7 @@ public struct FfiConverterTypeFfiPreferenceUpdate: FfiConverterRustBuffer {
         let variant: Int32 = try readInt(&buf)
         switch variant {
         
-        case 1: return .hmac(key: try FfiConverterData.read(from: &buf), cycledAtNs: try FfiConverterInt64.read(from: &buf)
+        case 1: return .hmac(key: try FfiConverterData.read(from: &buf)
         )
         
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -8039,10 +8039,9 @@ public struct FfiConverterTypeFfiPreferenceUpdate: FfiConverterRustBuffer {
         switch value {
         
         
-        case let .hmac(key,cycledAtNs):
+        case let .hmac(key):
             writeInt(&buf, Int32(1))
             FfiConverterData.write(key, into: &buf)
-            FfiConverterInt64.write(cycledAtNs, into: &buf)
             
         }
     }


### PR DESCRIPTION
This PR updates the Swift bindings to libxmtp version 4.2.0-rc2. 
  
Changes:
- Updated Sources directory with latest Swift bindings
- Updated LibXMTP.podspec version to 4.2.0-rc2
- Updated binary URLs to point to the new release
- Updated checksum in Package.swift