### PR TITLE
Update to libxmtp 4.2.0-rc3

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '4.2.0-rc2'
+  s.version          = '4.2.0-rc3'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '14.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-rc2.51542b6/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-rc3.b4e982c/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPSwiftFFI.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-rc2.51542b6/LibXMTPSwiftFFI.zip",
-            checksum: "7a153b398d8808c9025dcc20436a891159b18f0e5927e183b034b22d2f4b3cd5"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-rc3.b4e982c/LibXMTPSwiftFFI.zip",
+            checksum: "8fd73b153fdae60beee21e89990aad14953e911489228a6f0b5136943729f02a"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/Sources/LibXMTP/libxmtp-version.txt
+++ b/Sources/LibXMTP/libxmtp-version.txt
@@ -1,3 +1,3 @@
-Version: 51542b6
+Version: b4e982c
 Branch: HEAD
-Date: 2025-05-08 23:42:20 +0000
+Date: 2025-05-09 18:12:27 +0000


### PR DESCRIPTION
This PR updates the Swift bindings to libxmtp version 4.2.0-rc3. 
  
Changes:
- Updated Sources directory with latest Swift bindings
- Updated LibXMTP.podspec version to 4.2.0-rc3
- Updated binary URLs to point to the new release
- Updated checksum in Package.swift