### PR TITLE
Update to libxmtp 4.2.0

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '4.2.0-rc5'
+  s.version          = '4.2.0'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '14.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-rc5.d990224/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0.7b9b4d0/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPSwiftFFI.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0-rc5.d990224/LibXMTPSwiftFFI.zip",
-            checksum: "5731d60df470aa882d32c0c8c6d5e53f58c48e5ae6863cc31d35f80db7609427"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.0.7b9b4d0/LibXMTPSwiftFFI.zip",
+            checksum: "31bba41e1c03ceb573394be6df643debc9c2e231159184112599a54933ee40b9"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/Sources/LibXMTP/libxmtp-version.txt
+++ b/Sources/LibXMTP/libxmtp-version.txt
@@ -1,3 +1,3 @@
-Version: d990224
+Version: 7b9b4d0
 Branch: HEAD
-Date: 2025-05-29 00:31:52 +0000
+Date: 2025-05-30 15:19:49 +0000


### PR DESCRIPTION
This PR updates the Swift bindings to libxmtp version 4.2.0. 
  
Changes:
- Updated Sources directory with latest Swift bindings
- Updated LibXMTP.podspec version to 4.2.0
- Updated binary URLs to point to the new release
- Updated checksum in Package.swift