### PR TITLE
Update to libxmtp 4.2.3

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '4.2.2'
+  s.version          = '4.2.3'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '14.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.2.d0f0b67/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.3.b2feaef/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPSwiftFFI.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.2.d0f0b67/LibXMTPSwiftFFI.zip",
-            checksum: "840b4606d378522a4a91b170e22072ae9ff9a8c462d6aee2dd109b5b56a22b8c"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.3.b2feaef/LibXMTPSwiftFFI.zip",
+            checksum: "ba3a866095c74820c75ff83207012ee016457d22fbe125451255793147c02cd0"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/Sources/LibXMTP/libxmtp-version.txt
+++ b/Sources/LibXMTP/libxmtp-version.txt
@@ -1,3 +1,3 @@
-Version: d0f0b67
+Version: b2feaef
 Branch: HEAD
-Date: 2025-06-18 21:31:37 +0000
+Date: 2025-06-23 19:06:41 +0000

--- a/Sources/LibXMTP/xmtpv3.swift
+++ b/Sources/LibXMTP/xmtpv3.swift
@@ -10286,6 +10286,23 @@ fileprivate func uniffiFutureContinuationCallback(handle: UInt64, pollResult: In
         print("uniffiFutureContinuationCallback invalid handle")
     }
 }
+/**
+ * * Static apply a signature request
+ */
+public func applySignatureRequest(api: XmtpApiClient, signatureRequest: FfiSignatureRequest)async throws   {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_xmtpv3_fn_func_apply_signature_request(FfiConverterTypeXmtpApiClient_lower(api),FfiConverterTypeFfiSignatureRequest_lower(signatureRequest)
+                )
+            },
+            pollFunc: ffi_xmtpv3_rust_future_poll_void,
+            completeFunc: ffi_xmtpv3_rust_future_complete_void,
+            freeFunc: ffi_xmtpv3_rust_future_free_void,
+            liftFunc: { $0 },
+            errorHandler: FfiConverterTypeGenericError_lift
+        )
+}
 public func connectToBackend(host: String, isSecure: Bool)async throws  -> XmtpApiClient  {
     return
         try  await uniffiRustCallAsync(
@@ -10431,6 +10448,23 @@ public func getVersionInfo() -> String  {
     )
 })
 }
+/**
+ * * Static revoke a list of installations
+ */
+public func revokeInstallations(api: XmtpApiClient, recoveryIdentifier: FfiIdentifier, inboxId: String, installationIds: [Data])async throws  -> FfiSignatureRequest  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_xmtpv3_fn_func_revoke_installations(FfiConverterTypeXmtpApiClient_lower(api),FfiConverterTypeFfiIdentifier_lower(recoveryIdentifier),FfiConverterString.lower(inboxId),FfiConverterSequenceData.lower(installationIds)
+                )
+            },
+            pollFunc: ffi_xmtpv3_rust_future_poll_pointer,
+            completeFunc: ffi_xmtpv3_rust_future_complete_pointer,
+            freeFunc: ffi_xmtpv3_rust_future_free_pointer,
+            liftFunc: FfiConverterTypeFfiSignatureRequest_lift,
+            errorHandler: FfiConverterTypeGenericError_lift
+        )
+}
 
 private enum InitializationResult {
     case ok
@@ -10446,6 +10480,9 @@ private let initializationResult: InitializationResult = {
     let scaffolding_contract_version = ffi_xmtpv3_uniffi_contract_version()
     if bindings_contract_version != scaffolding_contract_version {
         return InitializationResult.contractVersionMismatch
+    }
+    if (uniffi_xmtpv3_checksum_func_apply_signature_request() != 65134) {
+        return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_func_connect_to_backend() != 26018) {
         return InitializationResult.apiChecksumMismatch
@@ -10481,6 +10518,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_func_get_version_info() != 29277) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_xmtpv3_checksum_func_revoke_installations() != 23629) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_fficonsentcallback_on_consent_update() != 12532) {


### PR DESCRIPTION
This PR updates the Swift bindings to libxmtp version 4.2.3. 
  
Changes:
- Updated Sources directory with latest Swift bindings
- Updated LibXMTP.podspec version to 4.2.3
- Updated binary URLs to point to the new release
- Updated checksum in Package.swift