### PR TITLE
Update to libxmtp 4.2.6

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '4.2.5'
+  s.version          = '4.2.6'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '14.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.5.dc3e8c8/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.6.bfeba9f/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPSwiftFFI.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.5.dc3e8c8/LibXMTPSwiftFFI.zip",
-            checksum: "83af5f00f5397e4839deda452a7c5251ffc4fbd2ad8d34a7f9923c4f8fd955c9"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.6.bfeba9f/LibXMTPSwiftFFI.zip",
+            checksum: "3c52f689132d309c0017835b25d29cc46c9eb43fe4378b249a75634a30fc255d"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/Sources/LibXMTP/libxmtp-version.txt
+++ b/Sources/LibXMTP/libxmtp-version.txt
@@ -1,3 +1,3 @@
-Version: dc3e8c8
+Version: bfeba9f
 Branch: HEAD
-Date: 2025-06-26 21:52:34 +0000
+Date: 2025-07-01 23:05:40 +0000


### PR DESCRIPTION
This PR updates the Swift bindings to libxmtp version 4.2.6. 
  
Changes:
- Updated Sources directory with latest Swift bindings
- Updated LibXMTP.podspec version to 4.2.6
- Updated binary URLs to point to the new release
- Updated checksum in Package.swift