### PR TITLE
Update to libxmtp 4.3.0-dev.d5f91eb

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '4.3.0-dev.d8c7ed3'
+  s.version          = '4.3.0-dev.d5f91eb'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '14.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.3.0-dev.d8c7ed3/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.3.0-dev.d5f91eb/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPSwiftFFI.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.3.0-dev.d8c7ed3/LibXMTPSwiftFFI.zip",
-            checksum: "19b6747af44c46c501063a162cff906434d226a22a771163427013abdb79a9b1"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.3.0-dev.d5f91eb/LibXMTPSwiftFFI.zip",
+            checksum: "aaa51cdaef13e0e03d94970129b2cba893b38ce118c27adfe5784852bf68a7bb"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/Sources/LibXMTP/libxmtp-version.txt
+++ b/Sources/LibXMTP/libxmtp-version.txt
@@ -1,3 +1,3 @@
-Version: d8c7ed3
+Version: d5f91eb
 Branch: HEAD
-Date: 2025-07-01 22:21:52 +0000
+Date: 2025-07-07 14:22:08 +0000

--- a/Sources/LibXMTP/xmtpv3.swift
+++ b/Sources/LibXMTP/xmtpv3.swift
@@ -5099,13 +5099,17 @@ public struct FfiConversationDebugInfo {
     public var epoch: UInt64
     public var maybeForked: Bool
     public var forkDetails: String
+    public var localCommitLog: String
+    public var cursor: Int64
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(epoch: UInt64, maybeForked: Bool, forkDetails: String) {
+    public init(epoch: UInt64, maybeForked: Bool, forkDetails: String, localCommitLog: String, cursor: Int64) {
         self.epoch = epoch
         self.maybeForked = maybeForked
         self.forkDetails = forkDetails
+        self.localCommitLog = localCommitLog
+        self.cursor = cursor
     }
 }
 
@@ -5125,6 +5129,12 @@ extension FfiConversationDebugInfo: Equatable, Hashable {
         if lhs.forkDetails != rhs.forkDetails {
             return false
         }
+        if lhs.localCommitLog != rhs.localCommitLog {
+            return false
+        }
+        if lhs.cursor != rhs.cursor {
+            return false
+        }
         return true
     }
 
@@ -5132,6 +5142,8 @@ extension FfiConversationDebugInfo: Equatable, Hashable {
         hasher.combine(epoch)
         hasher.combine(maybeForked)
         hasher.combine(forkDetails)
+        hasher.combine(localCommitLog)
+        hasher.combine(cursor)
     }
 }
 
@@ -5146,7 +5158,9 @@ public struct FfiConverterTypeFfiConversationDebugInfo: FfiConverterRustBuffer {
             try FfiConversationDebugInfo(
                 epoch: FfiConverterUInt64.read(from: &buf), 
                 maybeForked: FfiConverterBool.read(from: &buf), 
-                forkDetails: FfiConverterString.read(from: &buf)
+                forkDetails: FfiConverterString.read(from: &buf), 
+                localCommitLog: FfiConverterString.read(from: &buf), 
+                cursor: FfiConverterInt64.read(from: &buf)
         )
     }
 
@@ -5154,6 +5168,8 @@ public struct FfiConverterTypeFfiConversationDebugInfo: FfiConverterRustBuffer {
         FfiConverterUInt64.write(value.epoch, into: &buf)
         FfiConverterBool.write(value.maybeForked, into: &buf)
         FfiConverterString.write(value.forkDetails, into: &buf)
+        FfiConverterString.write(value.localCommitLog, into: &buf)
+        FfiConverterInt64.write(value.cursor, into: &buf)
     }
 }
 


### PR DESCRIPTION
This PR updates the Swift bindings to libxmtp version 4.3.0-dev.d5f91eb. 
  
Changes:
- Updated Sources directory with latest Swift bindings
- Updated LibXMTP.podspec version to 4.3.0-dev.d5f91eb
- Updated binary URLs to point to the new release
- Updated checksum in Package.swift