### PR TITLE
Update to libxmtp 4.2.8

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '4.3.0-dev.d5f91eb'
+  s.version          = '4.2.8'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '14.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.3.0-dev.d5f91eb/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.8.3562697/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPSwiftFFI.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.3.0-dev.d5f91eb/LibXMTPSwiftFFI.zip",
-            checksum: "aaa51cdaef13e0e03d94970129b2cba893b38ce118c27adfe5784852bf68a7bb"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.2.8.3562697/LibXMTPSwiftFFI.zip",
+            checksum: "ff285cf622f66b32e81dbfbde63f799ccc6d77e273cfd9cf315bfb6b71f63c2b"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/Sources/LibXMTP/libxmtp-version.txt
+++ b/Sources/LibXMTP/libxmtp-version.txt
@@ -1,3 +1,3 @@
-Version: d5f91eb
+Version: 3562697
 Branch: HEAD
-Date: 2025-07-07 14:22:08 +0000
+Date: 2025-07-10 18:27:35 +0000

--- a/Sources/LibXMTP/xmtpv3.swift
+++ b/Sources/LibXMTP/xmtpv3.swift
@@ -5099,17 +5099,13 @@ public struct FfiConversationDebugInfo {
     public var epoch: UInt64
     public var maybeForked: Bool
     public var forkDetails: String
-    public var localCommitLog: String
-    public var cursor: Int64
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(epoch: UInt64, maybeForked: Bool, forkDetails: String, localCommitLog: String, cursor: Int64) {
+    public init(epoch: UInt64, maybeForked: Bool, forkDetails: String) {
         self.epoch = epoch
         self.maybeForked = maybeForked
         self.forkDetails = forkDetails
-        self.localCommitLog = localCommitLog
-        self.cursor = cursor
     }
 }
 
@@ -5129,12 +5125,6 @@ extension FfiConversationDebugInfo: Equatable, Hashable {
         if lhs.forkDetails != rhs.forkDetails {
             return false
         }
-        if lhs.localCommitLog != rhs.localCommitLog {
-            return false
-        }
-        if lhs.cursor != rhs.cursor {
-            return false
-        }
         return true
     }
 
@@ -5142,8 +5132,6 @@ extension FfiConversationDebugInfo: Equatable, Hashable {
         hasher.combine(epoch)
         hasher.combine(maybeForked)
         hasher.combine(forkDetails)
-        hasher.combine(localCommitLog)
-        hasher.combine(cursor)
     }
 }
 
@@ -5158,9 +5146,7 @@ public struct FfiConverterTypeFfiConversationDebugInfo: FfiConverterRustBuffer {
             try FfiConversationDebugInfo(
                 epoch: FfiConverterUInt64.read(from: &buf), 
                 maybeForked: FfiConverterBool.read(from: &buf), 
-                forkDetails: FfiConverterString.read(from: &buf), 
-                localCommitLog: FfiConverterString.read(from: &buf), 
-                cursor: FfiConverterInt64.read(from: &buf)
+                forkDetails: FfiConverterString.read(from: &buf)
         )
     }
 
@@ -5168,8 +5154,6 @@ public struct FfiConverterTypeFfiConversationDebugInfo: FfiConverterRustBuffer {
         FfiConverterUInt64.write(value.epoch, into: &buf)
         FfiConverterBool.write(value.maybeForked, into: &buf)
         FfiConverterString.write(value.forkDetails, into: &buf)
-        FfiConverterString.write(value.localCommitLog, into: &buf)
-        FfiConverterInt64.write(value.cursor, into: &buf)
     }
 }
 
@@ -10354,11 +10338,11 @@ public func connectToBackend(host: String, isSecure: Bool)async throws  -> XmtpA
  * xmtp.create_client(account_identifier, nonce, inbox_id, Option<legacy_signed_private_key_proto>)
  * ```
  */
-public func createClient(api: XmtpApiClient, db: String?, encryptionKey: Data?, inboxId: String, accountIdentifier: FfiIdentifier, nonce: UInt64, legacySignedPrivateKeyProto: Data?, deviceSyncServerUrl: String?, deviceSyncMode: FfiSyncWorkerMode?, allowOffline: Bool?, disableEvents: Bool?)async throws  -> FfiXmtpClient  {
+public func createClient(api: XmtpApiClient, db: String?, encryptionKey: Data?, inboxId: String, accountIdentifier: FfiIdentifier, nonce: UInt64, legacySignedPrivateKeyProto: Data?, deviceSyncServerUrl: String?, deviceSyncMode: FfiSyncWorkerMode?, allowOffline: Bool?)async throws  -> FfiXmtpClient  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
-                uniffi_xmtpv3_fn_func_create_client(FfiConverterTypeXmtpApiClient_lower(api),FfiConverterOptionString.lower(db),FfiConverterOptionData.lower(encryptionKey),FfiConverterString.lower(inboxId),FfiConverterTypeFfiIdentifier_lower(accountIdentifier),FfiConverterUInt64.lower(nonce),FfiConverterOptionData.lower(legacySignedPrivateKeyProto),FfiConverterOptionString.lower(deviceSyncServerUrl),FfiConverterOptionTypeFfiSyncWorkerMode.lower(deviceSyncMode),FfiConverterOptionBool.lower(allowOffline),FfiConverterOptionBool.lower(disableEvents)
+                uniffi_xmtpv3_fn_func_create_client(FfiConverterTypeXmtpApiClient_lower(api),FfiConverterOptionString.lower(db),FfiConverterOptionData.lower(encryptionKey),FfiConverterString.lower(inboxId),FfiConverterTypeFfiIdentifier_lower(accountIdentifier),FfiConverterUInt64.lower(nonce),FfiConverterOptionData.lower(legacySignedPrivateKeyProto),FfiConverterOptionString.lower(deviceSyncServerUrl),FfiConverterOptionTypeFfiSyncWorkerMode.lower(deviceSyncMode),FfiConverterOptionBool.lower(allowOffline)
                 )
             },
             pollFunc: ffi_xmtpv3_rust_future_poll_pointer,
@@ -10465,6 +10449,38 @@ public func getVersionInfo() -> String  {
 })
 }
 /**
+ * * Static Get the inbox state for each `inbox_id`.
+ */
+public func inboxStateFromInboxIds(api: XmtpApiClient, inboxIds: [String])async throws  -> [FfiInboxState]  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_xmtpv3_fn_func_inbox_state_from_inbox_ids(FfiConverterTypeXmtpApiClient_lower(api),FfiConverterSequenceString.lower(inboxIds)
+                )
+            },
+            pollFunc: ffi_xmtpv3_rust_future_poll_rust_buffer,
+            completeFunc: ffi_xmtpv3_rust_future_complete_rust_buffer,
+            freeFunc: ffi_xmtpv3_rust_future_free_rust_buffer,
+            liftFunc: FfiConverterSequenceTypeFfiInboxState.lift,
+            errorHandler: FfiConverterTypeGenericError_lift
+        )
+}
+public func isConnected(api: XmtpApiClient)async  -> Bool  {
+    return
+        try!  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_xmtpv3_fn_func_is_connected(FfiConverterTypeXmtpApiClient_lower(api)
+                )
+            },
+            pollFunc: ffi_xmtpv3_rust_future_poll_i8,
+            completeFunc: ffi_xmtpv3_rust_future_complete_i8,
+            freeFunc: ffi_xmtpv3_rust_future_free_i8,
+            liftFunc: FfiConverterBool.lift,
+            errorHandler: nil
+            
+        )
+}
+/**
  * * Static revoke a list of installations
  */
 public func revokeInstallations(api: XmtpApiClient, recoveryIdentifier: FfiIdentifier, inboxId: String, installationIds: [Data])async throws  -> FfiSignatureRequest  {
@@ -10503,7 +10519,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_xmtpv3_checksum_func_connect_to_backend() != 26018) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_xmtpv3_checksum_func_create_client() != 36933) {
+    if (uniffi_xmtpv3_checksum_func_create_client() != 17231) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_func_decode_multi_remote_attachment() != 59746) {
@@ -10534,6 +10550,12 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_func_get_version_info() != 29277) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_xmtpv3_checksum_func_inbox_state_from_inbox_ids() != 55434) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_xmtpv3_checksum_func_is_connected() != 17295) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_func_revoke_installations() != 23629) {


### PR DESCRIPTION
This PR updates the Swift bindings to libxmtp version 4.2.8. 
  
Changes:
- Updated Sources directory with latest Swift bindings
- Updated LibXMTP.podspec version to 4.2.8
- Updated binary URLs to point to the new release
- Updated checksum in Package.swift