### PR TITLE
Update to libxmtp 4.3.0-rc2

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '4.3.0-rc1.1'
+  s.version          = '4.3.0-rc2'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '14.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.3.0-rc1.7af5163/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.3.0-rc2.89b7706/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPSwiftFFI.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.3.0-rc1.7af5163/LibXMTPSwiftFFI.zip",
-            checksum: "ded0c2d93a545e5c24dfd1fedb68e58dfa5dcea96de8fd009213758fe59813c9"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.3.0-rc2.89b7706/LibXMTPSwiftFFI.zip",
+            checksum: "b00b077af205dcc83062557de583216c56d9117d66cbd9d024daa2c0165b1cb6"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/Sources/LibXMTP/libxmtp-version.txt
+++ b/Sources/LibXMTP/libxmtp-version.txt
@@ -1,3 +1,3 @@
-Version: 7af5163
+Version: 89b7706
 Branch: HEAD
-Date: 2025-07-10 18:40:44 +0000
+Date: 2025-07-15 18:58:05 +0000


### PR DESCRIPTION
This PR updates the Swift bindings to libxmtp version 4.3.0-rc2. 
  
Changes:
- Updated Sources directory with latest Swift bindings
- Updated LibXMTP.podspec version to 4.3.0-rc2
- Updated binary URLs to point to the new release
- Updated checksum in Package.swift