### PR TITLE
Update to libxmtp 4.3.6

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '4.3.5'
+  s.version          = '4.3.6'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '14.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.3.5.e0f1a77/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.3.6.c99abce/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPSwiftFFI.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.3.5.e0f1a77/LibXMTPSwiftFFI.zip",
-            checksum: "0dfad5d71cfa2d61ddebc953b6bf8e7aba41cade9cff47d750dbd2f1a8a42e2d"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.3.6.c99abce/LibXMTPSwiftFFI.zip",
+            checksum: "5e094a8a752642f0bb7f56332a00a687efdc5e5571fb43d4c8f3b0b702fee2e1"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/Sources/LibXMTP/libxmtp-version.txt
+++ b/Sources/LibXMTP/libxmtp-version.txt
@@ -1,3 +1,3 @@
-Version: e0f1a77
+Version: c99abce
 Branch: HEAD
-Date: 2025-08-05 18:42:16 +0000
+Date: 2025-08-06 19:01:49 +0000


### PR DESCRIPTION
This PR updates the Swift bindings to libxmtp version 4.3.6. 
  
Changes:
- Updated Sources directory with latest Swift bindings
- Updated LibXMTP.podspec version to 4.3.6
- Updated binary URLs to point to the new release
- Updated checksum in Package.swift