### PR TITLE
Update to libxmtp 4.4.0-rc1

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '4.3.6'
+  s.version          = '4.4.0-rc1'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '14.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.3.6.c99abce/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.4.0-rc1.f7c7226/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPSwiftFFI.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.3.6.c99abce/LibXMTPSwiftFFI.zip",
-            checksum: "5e094a8a752642f0bb7f56332a00a687efdc5e5571fb43d4c8f3b0b702fee2e1"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.4.0-rc1.f7c7226/LibXMTPSwiftFFI.zip",
+            checksum: "385ec70ec65aaf6265420285ac552215209ea1e6454590393b66083de8f8f52b"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/Sources/LibXMTP/libxmtp-version.txt
+++ b/Sources/LibXMTP/libxmtp-version.txt
@@ -1,3 +1,3 @@
-Version: c99abce
+Version: f7c7226
 Branch: HEAD
-Date: 2025-08-06 19:01:49 +0000
+Date: 2025-08-13 22:20:36 +0000

--- a/Sources/LibXMTP/xmtpv3.swift
+++ b/Sources/LibXMTP/xmtpv3.swift
@@ -1848,6 +1848,8 @@ public protocol FfiConversationListItemProtocol: AnyObject, Sendable {
     
     func conversation()  -> FfiConversation
     
+    func isCommitLogForked()  -> Bool?
+    
     func lastMessage()  -> FfiMessage?
     
 }
@@ -1906,6 +1908,13 @@ open class FfiConversationListItem: FfiConversationListItemProtocol, @unchecked 
 open func conversation() -> FfiConversation  {
     return try!  FfiConverterTypeFfiConversation_lift(try! rustCall() {
     uniffi_xmtpv3_fn_method_fficonversationlistitem_conversation(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isCommitLogForked() -> Bool?  {
+    return try!  FfiConverterOptionBool.lift(try! rustCall() {
+    uniffi_xmtpv3_fn_method_fficonversationlistitem_is_commit_log_forked(self.uniffiClonePointer(),$0
     )
 })
 }
@@ -5216,15 +5225,17 @@ public struct FfiConversationDebugInfo {
     public var epoch: UInt64
     public var maybeForked: Bool
     public var forkDetails: String
+    public var isCommitLogForked: Bool?
     public var localCommitLog: String
     public var cursor: Int64
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(epoch: UInt64, maybeForked: Bool, forkDetails: String, localCommitLog: String, cursor: Int64) {
+    public init(epoch: UInt64, maybeForked: Bool, forkDetails: String, isCommitLogForked: Bool?, localCommitLog: String, cursor: Int64) {
         self.epoch = epoch
         self.maybeForked = maybeForked
         self.forkDetails = forkDetails
+        self.isCommitLogForked = isCommitLogForked
         self.localCommitLog = localCommitLog
         self.cursor = cursor
     }
@@ -5246,6 +5257,9 @@ extension FfiConversationDebugInfo: Equatable, Hashable {
         if lhs.forkDetails != rhs.forkDetails {
             return false
         }
+        if lhs.isCommitLogForked != rhs.isCommitLogForked {
+            return false
+        }
         if lhs.localCommitLog != rhs.localCommitLog {
             return false
         }
@@ -5259,6 +5273,7 @@ extension FfiConversationDebugInfo: Equatable, Hashable {
         hasher.combine(epoch)
         hasher.combine(maybeForked)
         hasher.combine(forkDetails)
+        hasher.combine(isCommitLogForked)
         hasher.combine(localCommitLog)
         hasher.combine(cursor)
     }
@@ -5276,6 +5291,7 @@ public struct FfiConverterTypeFfiConversationDebugInfo: FfiConverterRustBuffer {
                 epoch: FfiConverterUInt64.read(from: &buf), 
                 maybeForked: FfiConverterBool.read(from: &buf), 
                 forkDetails: FfiConverterString.read(from: &buf), 
+                isCommitLogForked: FfiConverterOptionBool.read(from: &buf), 
                 localCommitLog: FfiConverterString.read(from: &buf), 
                 cursor: FfiConverterInt64.read(from: &buf)
         )
@@ -5285,6 +5301,7 @@ public struct FfiConverterTypeFfiConversationDebugInfo: FfiConverterRustBuffer {
         FfiConverterUInt64.write(value.epoch, into: &buf)
         FfiConverterBool.write(value.maybeForked, into: &buf)
         FfiConverterString.write(value.forkDetails, into: &buf)
+        FfiConverterOptionBool.write(value.isCommitLogForked, into: &buf)
         FfiConverterString.write(value.localCommitLog, into: &buf)
         FfiConverterInt64.write(value.cursor, into: &buf)
     }
@@ -11086,6 +11103,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_fficonversationlistitem_conversation() != 20525) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_xmtpv3_checksum_method_fficonversationlistitem_is_commit_log_forked() != 16358) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_fficonversationlistitem_last_message() != 42510) {


### PR DESCRIPTION
This PR updates the Swift bindings to libxmtp version 4.4.0-rc1. 
  
Changes:
- Updated Sources directory with latest Swift bindings
- Updated LibXMTP.podspec version to 4.4.0-rc1
- Updated binary URLs to point to the new release
- Updated checksum in Package.swift