### PR TITLE
Update to libxmtp 4.4.0-rc2

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '4.4.0-rc1'
+  s.version          = '4.4.0-rc2'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '14.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.4.0-rc1.f7c7226/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.4.0-rc2.4490a41/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPSwiftFFI.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.4.0-rc1.f7c7226/LibXMTPSwiftFFI.zip",
-            checksum: "385ec70ec65aaf6265420285ac552215209ea1e6454590393b66083de8f8f52b"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.4.0-rc2.4490a41/LibXMTPSwiftFFI.zip",
+            checksum: "5a3cdb86303fa7f4271947ab686e7f6784a891d650dbb4ffe0e89afdc8ae7458"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/Sources/LibXMTP/libxmtp-version.txt
+++ b/Sources/LibXMTP/libxmtp-version.txt
@@ -1,3 +1,3 @@
-Version: f7c7226
+Version: 4490a41
 Branch: HEAD
-Date: 2025-08-13 22:20:36 +0000
+Date: 2025-08-20 06:42:10 +0000

--- a/Sources/LibXMTP/xmtpv3.swift
+++ b/Sources/LibXMTP/xmtpv3.swift
@@ -5227,16 +5227,18 @@ public struct FfiConversationDebugInfo {
     public var forkDetails: String
     public var isCommitLogForked: Bool?
     public var localCommitLog: String
+    public var remoteCommitLog: String
     public var cursor: Int64
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(epoch: UInt64, maybeForked: Bool, forkDetails: String, isCommitLogForked: Bool?, localCommitLog: String, cursor: Int64) {
+    public init(epoch: UInt64, maybeForked: Bool, forkDetails: String, isCommitLogForked: Bool?, localCommitLog: String, remoteCommitLog: String, cursor: Int64) {
         self.epoch = epoch
         self.maybeForked = maybeForked
         self.forkDetails = forkDetails
         self.isCommitLogForked = isCommitLogForked
         self.localCommitLog = localCommitLog
+        self.remoteCommitLog = remoteCommitLog
         self.cursor = cursor
     }
 }
@@ -5263,6 +5265,9 @@ extension FfiConversationDebugInfo: Equatable, Hashable {
         if lhs.localCommitLog != rhs.localCommitLog {
             return false
         }
+        if lhs.remoteCommitLog != rhs.remoteCommitLog {
+            return false
+        }
         if lhs.cursor != rhs.cursor {
             return false
         }
@@ -5275,6 +5280,7 @@ extension FfiConversationDebugInfo: Equatable, Hashable {
         hasher.combine(forkDetails)
         hasher.combine(isCommitLogForked)
         hasher.combine(localCommitLog)
+        hasher.combine(remoteCommitLog)
         hasher.combine(cursor)
     }
 }
@@ -5293,6 +5299,7 @@ public struct FfiConverterTypeFfiConversationDebugInfo: FfiConverterRustBuffer {
                 forkDetails: FfiConverterString.read(from: &buf), 
                 isCommitLogForked: FfiConverterOptionBool.read(from: &buf), 
                 localCommitLog: FfiConverterString.read(from: &buf), 
+                remoteCommitLog: FfiConverterString.read(from: &buf), 
                 cursor: FfiConverterInt64.read(from: &buf)
         )
     }
@@ -5303,6 +5310,7 @@ public struct FfiConverterTypeFfiConversationDebugInfo: FfiConverterRustBuffer {
         FfiConverterString.write(value.forkDetails, into: &buf)
         FfiConverterOptionBool.write(value.isCommitLogForked, into: &buf)
         FfiConverterString.write(value.localCommitLog, into: &buf)
+        FfiConverterString.write(value.remoteCommitLog, into: &buf)
         FfiConverterInt64.write(value.cursor, into: &buf)
     }
 }


### PR DESCRIPTION
This PR updates the Swift bindings to libxmtp version 4.4.0-rc2. 
  
Changes:
- Updated Sources directory with latest Swift bindings
- Updated LibXMTP.podspec version to 4.4.0-rc2
- Updated binary URLs to point to the new release
- Updated checksum in Package.swift