### PR TITLE
Update to libxmtp 4.4.0

### DIFF
--- a/LibXMTP.podspec
+++ b/LibXMTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LibXMTP'
-  s.version          = '4.3.7'
+  s.version          = '4.4.0'
   s.summary          = 'XMTP shared Rust code that powers cross-platform SDKs'
 
   s.homepage         = 'https://github.com/xmtp/libxmtp-swift'
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '14.0', :macos, '11.0'
   s.swift_version    = '5.3'
 
-  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.3.7.e3e735c/LibXMTPSwiftFFI.zip", :type => :zip }
+  s.source           = { :http => "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.4.0.a9d19aa/LibXMTPSwiftFFI.zip", :type => :zip }
   s.vendored_frameworks = 'LibXMTPSwiftFFI.xcframework'
   s.source_files = 'Sources/LibXMTP/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "LibXMTPSwiftFFI",
-            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.3.7.e3e735c/LibXMTPSwiftFFI.zip",
-            checksum: "3c9a8abccac026312045b286bfe52430a3c7084c4bf55a0fb25103a988c71861"
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.4.0.a9d19aa/LibXMTPSwiftFFI.zip",
+            checksum: "a4bcf78ced5f4dd80c161a17a498bac508a30b59f72dfba9c5318020528ccc0e"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]

--- a/Sources/LibXMTP/libxmtp-version.txt
+++ b/Sources/LibXMTP/libxmtp-version.txt
@@ -1,3 +1,3 @@
-Version: e3e735c
+Version: a9d19aa
 Branch: HEAD
-Date: 2025-08-20 23:25:05 +0000
+Date: 2025-08-25 21:45:01 +0000

--- a/Sources/LibXMTP/xmtpv3.swift
+++ b/Sources/LibXMTP/xmtpv3.swift
@@ -1848,6 +1848,8 @@ public protocol FfiConversationListItemProtocol: AnyObject, Sendable {
     
     func conversation()  -> FfiConversation
     
+    func isCommitLogForked()  -> Bool?
+    
     func lastMessage()  -> FfiMessage?
     
 }
@@ -1906,6 +1908,13 @@ open class FfiConversationListItem: FfiConversationListItemProtocol, @unchecked 
 open func conversation() -> FfiConversation  {
     return try!  FfiConverterTypeFfiConversation_lift(try! rustCall() {
     uniffi_xmtpv3_fn_method_fficonversationlistitem_conversation(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isCommitLogForked() -> Bool?  {
+    return try!  FfiConverterOptionBool.lift(try! rustCall() {
+    uniffi_xmtpv3_fn_method_fficonversationlistitem_is_commit_log_forked(self.uniffiClonePointer(),$0
     )
 })
 }
@@ -5216,16 +5225,20 @@ public struct FfiConversationDebugInfo {
     public var epoch: UInt64
     public var maybeForked: Bool
     public var forkDetails: String
+    public var isCommitLogForked: Bool?
     public var localCommitLog: String
+    public var remoteCommitLog: String
     public var cursor: Int64
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(epoch: UInt64, maybeForked: Bool, forkDetails: String, localCommitLog: String, cursor: Int64) {
+    public init(epoch: UInt64, maybeForked: Bool, forkDetails: String, isCommitLogForked: Bool?, localCommitLog: String, remoteCommitLog: String, cursor: Int64) {
         self.epoch = epoch
         self.maybeForked = maybeForked
         self.forkDetails = forkDetails
+        self.isCommitLogForked = isCommitLogForked
         self.localCommitLog = localCommitLog
+        self.remoteCommitLog = remoteCommitLog
         self.cursor = cursor
     }
 }
@@ -5246,7 +5259,13 @@ extension FfiConversationDebugInfo: Equatable, Hashable {
         if lhs.forkDetails != rhs.forkDetails {
             return false
         }
+        if lhs.isCommitLogForked != rhs.isCommitLogForked {
+            return false
+        }
         if lhs.localCommitLog != rhs.localCommitLog {
+            return false
+        }
+        if lhs.remoteCommitLog != rhs.remoteCommitLog {
             return false
         }
         if lhs.cursor != rhs.cursor {
@@ -5259,7 +5278,9 @@ extension FfiConversationDebugInfo: Equatable, Hashable {
         hasher.combine(epoch)
         hasher.combine(maybeForked)
         hasher.combine(forkDetails)
+        hasher.combine(isCommitLogForked)
         hasher.combine(localCommitLog)
+        hasher.combine(remoteCommitLog)
         hasher.combine(cursor)
     }
 }
@@ -5276,7 +5297,9 @@ public struct FfiConverterTypeFfiConversationDebugInfo: FfiConverterRustBuffer {
                 epoch: FfiConverterUInt64.read(from: &buf), 
                 maybeForked: FfiConverterBool.read(from: &buf), 
                 forkDetails: FfiConverterString.read(from: &buf), 
+                isCommitLogForked: FfiConverterOptionBool.read(from: &buf), 
                 localCommitLog: FfiConverterString.read(from: &buf), 
+                remoteCommitLog: FfiConverterString.read(from: &buf), 
                 cursor: FfiConverterInt64.read(from: &buf)
         )
     }
@@ -5285,7 +5308,9 @@ public struct FfiConverterTypeFfiConversationDebugInfo: FfiConverterRustBuffer {
         FfiConverterUInt64.write(value.epoch, into: &buf)
         FfiConverterBool.write(value.maybeForked, into: &buf)
         FfiConverterString.write(value.forkDetails, into: &buf)
+        FfiConverterOptionBool.write(value.isCommitLogForked, into: &buf)
         FfiConverterString.write(value.localCommitLog, into: &buf)
+        FfiConverterString.write(value.remoteCommitLog, into: &buf)
         FfiConverterInt64.write(value.cursor, into: &buf)
     }
 }
@@ -11086,6 +11111,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_fficonversationlistitem_conversation() != 20525) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_xmtpv3_checksum_method_fficonversationlistitem_is_commit_log_forked() != 16358) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_xmtpv3_checksum_method_fficonversationlistitem_last_message() != 42510) {


### PR DESCRIPTION
This PR updates the Swift bindings to libxmtp version 4.4.0. 
  
Changes:
- Updated Sources directory with latest Swift bindings
- Updated LibXMTP.podspec version to 4.4.0
- Updated binary URLs to point to the new release
- Updated checksum in Package.swift