### PR TITLE
Add dynamic library declaration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,14 @@ let package = Package(
     products: [
         .library(
             name: "LibXMTP",
+            type: .static,
             targets: ["LibXMTP", "LibXMTPSwiftFFI"]
         ),
+        .library(
+            name: "LibXMTP"
+            type: .dynamic
+            targets: ["LibXMTPDynamic"]
+        )
     ],
     targets: [
         .target(
@@ -29,6 +35,20 @@ let package = Package(
             name: "LibXMTPSwiftFFI",
             url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.4.0.a9d19aa/LibXMTPSwiftFFI.zip",
             checksum: "a4bcf78ced5f4dd80c161a17a498bac508a30b59f72dfba9c5318020528ccc0e"
+        ),
+        .target(
+            name: "LibXMTPDynamic",
+            dependencies: ["LibXMTPSwiftFFIDynamic"],
+            path: "Sources/LibXMTP",
+            linkerSettings: [
+                .linkedFramework("CoreFoundation"),
+                .linkedFramework("SystemConfiguration")
+            ]
+        ),
+        .binaryTarget(
+            name: "LibXMTPSwiftFFIDynamic",
+            url: "https://github.com/xmtp/libxmtp/releases/download/swift-bindings-1.4.0.a9d19aa/LibXMTPSwiftFFIDynamic.zip",
+            checksum: "0000000000000000000000000000000000000000000000000000000000000000"
         ),
         .testTarget(name: "LibXMTPTests", dependencies: ["LibXMTP"]),
     ]


### PR DESCRIPTION
the `binaryTarget` is stubbed until a checksum/url which will be updated next time the `update-swift-repo` workflow is ran after [dynamic pr](https://github.com/xmtp/libxmtp/pull/2654) is merged