### PR TITLE
Mark Repo Deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# LibXMTP Swift
 
-> **⚠️ DEPRECATED ⚠️**
-> 
+
+> ## **⚠️ DEPRECATED ⚠️**
+> ## LibXMTP Swift
 > This repository is deprecated and is no longer actively maintained. Please do not use this package for new projects.
 
 Swift Package and Cocoapod that wraps an XCFramework emitted by the `bindings_ffi` crate in [libxmtp](https://github.com/xmtp/libxmtp)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # LibXMTP Swift
 
+> **⚠️ DEPRECATED ⚠️**
+> 
+> This repository is deprecated and is no longer actively maintained. Please do not use this package for new projects.
+
 Swift Package and Cocoapod that wraps an XCFramework emitted by the `bindings_ffi` crate in [libxmtp](https://github.com/xmtp/libxmtp)
 
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 
 
 > ## **⚠️ DEPRECATED ⚠️**
-> ## LibXMTP Swift
 > This repository is deprecated and is no longer actively maintained. Please do not use this package for new projects.
+ ## LibXMTP Swift
 
 Swift Package and Cocoapod that wraps an XCFramework emitted by the `bindings_ffi` crate in [libxmtp](https://github.com/xmtp/libxmtp)
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add deprecation notice to README to mark repository as deprecated for new projects
Add a deprecation block at the top of [README.md](https://github.com/xmtp/libxmtp-swift/pull/196/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) and adjust the main heading level.

- Insert a deprecation notice at the top of [README.md](https://github.com/xmtp/libxmtp-swift/pull/196/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)
- Change the main title from H1 to H2 in [README.md](https://github.com/xmtp/libxmtp-swift/pull/196/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)

#### 📍Where to Start
Start with the deprecation notice section at the top of [README.md](https://github.com/xmtp/libxmtp-swift/pull/196/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f8eb8ab. 0 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->